### PR TITLE
Combine multiple when keys using list.

### DIFF
--- a/tasks/acme.yml
+++ b/tasks/acme.yml
@@ -38,12 +38,13 @@
 - include: acme-challenge.yml
   with_items:
     - "{{ tls_cert_acme_challenge.results }}"
-  when: acme_challenge.item.type == "acme" and acme_challenge|changed
+  when:
+    - tls_cert_acme_challenge | default(false) 
+    - acme_challenge.item.type == "acme" and acme_challenge|changed
   loop_control:
     loop_var:  acme_challenge
   tags:
   - tls_cert_acme
-  when: "{{ tls_cert_acme_challenge | default(false) }}"
 
 - name: Encrypted ACME account key exists.
   command: >


### PR DESCRIPTION
I'm not 100% sure, but I think the second `when:` clause is over-riding the first one, resulting in `acme-challenge.yml` always running, which fails out on unchanged certs because they have no challenge data. 

On the original code, `yamlint` reports
```
 46:3      error    duplication of key "when" in mapping  (key-duplicates)
```
which would seem to back me up, and we appear to get the correct behavior after combining the clauses into a `when` list. 