### PR TITLE
Clean-up, Document, and Update openssl template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--- Replace this with the title of your PR, or specify the title above and delete this line-->
+
+<!--- Replace this with a detailed description of your changes -->
+
+Motivation and Context
+----------------------
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it relates to an open issue or another pull request, please link to that here. -->
+
+How Has This Been Tested?
+-------------------------
+

--- a/tasks/acme.yml
+++ b/tasks/acme.yml
@@ -19,7 +19,7 @@
   file:
     path: "{{ tls_cert_path }}/{{ item.common_name }}/acme/.well-known/acme-challenge"
     state: directory
-    recurse: yes
+    recurse: true
   with_items: "{{ tls_certificates }}"
   when: item.type == "acme"
 
@@ -39,12 +39,12 @@
   with_items:
     - "{{ tls_cert_acme_challenge.results }}"
   when:
-    - tls_cert_acme_challenge | default(false) 
+    - tls_cert_acme_challenge | default(false)
     - acme_challenge.item.type == "acme" and acme_challenge|changed
   loop_control:
-    loop_var:  acme_challenge
+    loop_var: acme_challenge
   tags:
-  - tls_cert_acme
+    - tls_cert_acme
 
 - name: Encrypted ACME account key exists.
   command: >

--- a/tasks/acme.yml
+++ b/tasks/acme.yml
@@ -19,7 +19,7 @@
   file:
     path: "{{ tls_cert_path }}/{{ item.common_name }}/acme/.well-known/acme-challenge"
     state: directory
-    recurse: true
+    recurse: yes
   with_items: "{{ tls_certificates }}"
   when: item.type == "acme"
 

--- a/tasks/dhparam.yml
+++ b/tasks/dhparam.yml
@@ -1,11 +1,15 @@
 ---
 
+# We'll use Diffie Hellman key exchange to improve the forward security of
+# communication.  This means the servers private keys are not directly used
+# when encrypting data.
 - name: Diffie Hellman ephemeral parameters
   command: openssl dhparam -out dhparam.pem 4096
   args:
     chdir: "{{ tls_cert_path }}"
     creates: "{{ tls_cert_path }}/dhparam.*"
 
+# Make sure this file is automatically protected by vault.
 - name: Encrypted Diffie Hellman ephemeral parameters exists.
   command: >
     ansible-vault encrypt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,35 +1,42 @@
 ---
 # tasks file for tls-cert
 
+# Install  openssl
 - include: yum.yml
   when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7"))
   become: true
   tags:
   - tls_cert_yum
 
+# make tls cert path folder
 - include: config.yml
   tags:
   - tls_cert_config
 
+# We use Diffie Helman key exchange for forward security
 - include: dhparam.yml
   tags:
   - tls_cert_dhparam
 
+# Prep certificate requests and keys
 - include: req.yml
   tags:
   - tls_cert_req
   with_items: "{{ tls_certificates }}"
 
+# Generate self-signed certs
 - include: self-signed.yml
   tags:
   - tls_cert_self_signed
   with_items: "{{ tls_certificates }}"
   when: item.type == "self-signed"
 
+# Generate and upload acme challenge files and request certs
 - include: acme.yml
   tags:
   - tls_cert_acme
 
+# Take certs apart and rebuild them with full chain
 - include: chain.yml
   tags:
   - tls_cert_chain

--- a/tasks/req.yml
+++ b/tasks/req.yml
@@ -12,25 +12,12 @@
 
 - name: TLS key and CSR exist.
   shell: >
-     TLS_CERT_CN={{ item.common_name }}
-     {% if ((item.alt_names is defined) and (item.alt_names is not none)) %}
-     TLS_CERT_SAN="
-     {% for alt_name in item.alt_names %}
-     {% if ((alt_name is defined) and (alt_name is not none)) %}
-     DNS:{{ alt_name }}{{ "," if not loop.last else "" }}
-     {% endif %}{% endfor %}"{% else %}
-     {% endif %}
-     openssl req -config {{ tls_cert_path }}/{{ item.common_name }}/openssl.cnf -new -newkey rsa -nodes
+     openssl req -new -newkey rsa -nodes
+     -config {{ tls_cert_path }}/{{ item.common_name }}/openssl.cnf 
      -keyout {{ tls_cert_path }}/{{ item.common_name }}/privkey.pem
      -out {{ tls_cert_path }}/{{ item.common_name }}/request.csr
   args:
     creates: "{{ tls_cert_path }}/{{ item.common_name }}/privkey.*"
-  environment:
-    TLS_CERT_C: "{{ tls_cert_country }}"
-    TLC_CERT_ST: "{{ tls_cert_state }}"
-    TLS_CERT_L: "{{ tls_cert_locality }}"
-    TLS_CERT_O: "{{ tls_cert_organization }}"
-    TLS_CERT_OU: "{{ tls_cert_department }}"
 
 - name: Encrypted TLS key exists.
   command: >

--- a/tasks/req.yml
+++ b/tasks/req.yml
@@ -13,7 +13,7 @@
 - name: TLS key and CSR exist.
   shell: >
      openssl req -new -newkey rsa -nodes
-     -config {{ tls_cert_path }}/{{ item.common_name }}/openssl.cnf 
+     -config {{ tls_cert_path }}/{{ item.common_name }}/openssl.cnf
      -keyout {{ tls_cert_path }}/{{ item.common_name }}/privkey.pem
      -out {{ tls_cert_path }}/{{ item.common_name }}/request.csr
   args:

--- a/tasks/self-signed.yml
+++ b/tasks/self-signed.yml
@@ -12,27 +12,13 @@
 
 - name: Self-signed TLS key exists.
   shell: >
-     TLS_CERT_CN={{ item.common_name }}
-     {% if ((item.alt_names is defined) and (item.alt_names is not none)) %}
-     TLS_CERT_SAN="
-     {% for alt_name in item.alt_names %}
-     {% if ((alt_name is defined) and (alt_name is not none)) %}
-     DNS:{{ alt_name }}{{ "," if not loop.last else "" }}
-     {% endif %}{% endfor %}"{% else %}
-     {% endif %}
      openssl x509 -req -extensions v3_req
-     -extfile {{ tls_cert_path }}/{{ item.common_name }}/openssl.cnf
-     -in "{{ tls_cert_path }}"/"{{ item.common_name }}"/request.csr
-     -signkey "{{ tls_cert_path }}"/"{{ item.common_name }}"/privkey.pem
-     -out "{{ tls_cert_path }}"/"{{ item.common_name }}"/fullchain.pem
+     -extfile "{{ tls_cert_path }}/{{ item.common_name }}/openssl.cnf"
+     -in "{{ tls_cert_path }}/{{ item.common_name }}/request.csr"
+     -signkey "{{ tls_cert_path }}/{{ item.common_name }}/privkey.pem"
+     -out "{{ tls_cert_path }}/{{ item.common_name }}/fullchain.pem"
   args:
     creates: "{{ tls_cert_path }}/{{ item.common_name }}/fullchain.pem"
-  environment:
-    TLS_CERT_C: "{{ tls_cert_country }}"
-    TLC_CERT_ST: "{{ tls_cert_state }}"
-    TLS_CERT_L: "{{ tls_cert_locality }}"
-    TLS_CERT_O: "{{ tls_cert_organization }}"
-    TLS_CERT_OU: "{{ tls_cert_department }}"
   when: item.type == "self-signed"
 
 - name: Unencrypted TLS key is absent.

--- a/templates/openssl.cnf.j2
+++ b/templates/openssl.cnf.j2
@@ -27,6 +27,3 @@ subjectAltName = @alt_names
 {% endif %}
 {% endfor %}
 {% endif %}
-
-
-

--- a/templates/openssl.cnf.j2
+++ b/templates/openssl.cnf.j2
@@ -6,16 +6,27 @@ req_extensions = v3_req
 prompt = no
 
 [req_distinguished_name]
-C = ${ENV::TLS_CERT_C}
-ST = ${ENV::TLC_CERT_ST}
-L = ${ENV::TLS_CERT_L}
-O = ${ENV::TLS_CERT_O}
-OU = ${ENV::TLS_CERT_OU}
-CN = ${ENV::TLS_CERT_CN}
+countryName =  {{ tls_cert_country }}
+stateOrProvinceName =  {{tls_cert_state }}
+localityName =  {{tls_cert_locality }}
+organizationName =  {{tls_cert_organization }}
+organizationalUnitName = {{ tls_cert_department }}
+commonName =  {{item.common_name}}
 
 [v3_req]
 basicConstraints = CA:false
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 {% if ((item.alt_names is defined) and (item.alt_names is not none)) %}
-subjectAltName = ${ENV::TLS_CERT_SAN}
+subjectAltName = @alt_names
 {% endif %}
+
+{% if ((item.alt_names is defined) and (item.alt_names is not none)) %}
+[alt_names]
+{% for alt_name in item.alt_names %}
+{% if ((alt_name is defined) and (alt_name is not none)) %}DNS.{{loop.index}} = {{ alt_name }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+
+


### PR DESCRIPTION
This PR:
* adds some comments
* applies cleanup based on linting
* adds are PR temaplate 
* Neatens format of SAN in CSR. 
* Moves openssl environment variables to templated config file. 

Motivation and Context
----------------------
We're reorganizing some of our SSL stuff, and this cleanup PR is a side effect of reading through things. 

How Has This Been Tested?
-------------------------
Functional changes tested in vagrant. New SAN format is functionally equivalent to old one, and has served as the basis for successful CSRs. 